### PR TITLE
remove redundant type assertions

### DIFF
--- a/converters.go
+++ b/converters.go
@@ -8,24 +8,24 @@ type DstType generic.Type
 
 func ifaceTODstType(i interface{}) DstType {
 	var idx DstType
-	switch i.(type) {
+	switch i := i.(type) {
 	case int:
-		idx = DstType(i.(int))
+		idx = DstType(i)
 	case int16:
-		idx = DstType(i.(int16))
+		idx = DstType(i)
 	case int32:
-		idx = DstType(i.(int32))
+		idx = DstType(i)
 	case int64:
-		idx = DstType(i.(int64))
+		idx = DstType(i)
 
 	case uint:
-		idx = DstType(i.(int))
+		idx = DstType(i)
 	case uint16:
-		idx = DstType(i.(uint16))
+		idx = DstType(i)
 	case uint32:
-		idx = DstType(i.(uint32))
+		idx = DstType(i)
 	case uint64:
-		idx = DstType(i.(uint64))
+		idx = DstType(i)
 	}
 	return idx
 }

--- a/gen-converters.go
+++ b/gen-converters.go
@@ -4,26 +4,74 @@
 
 package gonetmap
 
-func ifaceTOint(i interface{}) int {
+func ifaceTOInt(i interface{}) int {
 	var idx int
-	switch i.(type) {
+	switch i := i.(type) {
 	case int:
-		idx = int(i.(int))
+		idx = int(i)
 	case int16:
-		idx = int(i.(int16))
+		idx = int(i)
 	case int32:
-		idx = int(i.(int32))
+		idx = int(i)
 	case int64:
-		idx = int(i.(int64))
+		idx = int(i)
 
 	case uint:
-		idx = int(i.(int))
+		idx = int(i)
 	case uint16:
-		idx = int(i.(uint16))
+		idx = int(i)
 	case uint32:
-		idx = int(i.(uint32))
+		idx = int(i)
 	case uint64:
-		idx = int(i.(uint64))
+		idx = int(i)
+	}
+	return idx
+}
+
+func ifaceTOUint16(i interface{}) uint16 {
+	var idx uint16
+	switch i := i.(type) {
+	case int:
+		idx = uint16(i)
+	case int16:
+		idx = uint16(i)
+	case int32:
+		idx = uint16(i)
+	case int64:
+		idx = uint16(i)
+
+	case uint:
+		idx = uint16(i)
+	case uint16:
+		idx = uint16(i)
+	case uint32:
+		idx = uint16(i)
+	case uint64:
+		idx = uint16(i)
+	}
+	return idx
+}
+
+func ifaceTOUint32(i interface{}) uint32 {
+	var idx uint32
+	switch i := i.(type) {
+	case int:
+		idx = uint32(i)
+	case int16:
+		idx = uint32(i)
+	case int32:
+		idx = uint32(i)
+	case int64:
+		idx = uint32(i)
+
+	case uint:
+		idx = uint32(i)
+	case uint16:
+		idx = uint32(i)
+	case uint32:
+		idx = uint32(i)
+	case uint64:
+		idx = uint32(i)
 	}
 	return idx
 }

--- a/utils.go
+++ b/utils.go
@@ -13,48 +13,48 @@ func PtrSliceFrom(p unsafe.Pointer, s int) unsafe.Pointer {
 
 func ifaceTOuint16(i interface{}) uint16 {
 	var idx uint16
-	switch i.(type) {
+	switch i := i.(type) {
 	case int:
-		idx = uint16(i.(int))
+		idx = uint16(i)
 	case int16:
-		idx = uint16(i.(int16))
+		idx = uint16(i)
 	case int32:
-		idx = uint16(i.(int32))
+		idx = uint16(i)
 	case int64:
-		idx = uint16(i.(int64))
+		idx = uint16(i)
 
 	case uint:
-		idx = uint16(i.(uint))
+		idx = uint16(i)
 	case uint16:
-		idx = uint16(i.(uint16))
+		idx = uint16(i)
 	case uint32:
-		idx = uint16(i.(uint32))
+		idx = uint16(i)
 	case uint64:
-		idx = uint16(i.(uint64))
+		idx = uint16(i)
 	}
 	return idx
 }
 
 func ifaceTOuint32(i interface{}) uint32 {
 	var idx uint32
-	switch i.(type) {
+	switch i := i.(type) {
 	case int:
-		idx = uint32(i.(int))
+		idx = uint32(i)
 	case int16:
-		idx = uint32(i.(int16))
+		idx = uint32(i)
 	case int32:
-		idx = uint32(i.(int32))
+		idx = uint32(i)
 	case int64:
-		idx = uint32(i.(int64))
+		idx = uint32(i)
 
 	case uint:
-		idx = uint32(i.(uint))
+		idx = uint32(i)
 	case uint16:
-		idx = uint32(i.(uint16))
+		idx = uint32(i)
 	case uint32:
-		idx = uint32(i.(uint32))
+		idx = uint32(i)
 	case uint64:
-		idx = uint32(i.(uint64))
+		idx = uint32(i)
 	}
 	return idx
 }


### PR DESCRIPTION
Use type switch with a bound var to avoid redundant
type assertions inside case clauses.

Also ran "go generate".

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>