### PR TITLE
refactor code a bit

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -13,7 +13,7 @@ type NetmapIf struct {
 	RxRings    uint32
 	BufsHead   uint32
 	Spare1     [5]uint32
-	RingOffset unsafe.Pointer //NmRing is here
+	RingOffset unsafe.Pointer // NmRing is here
 }
 
 type Interface struct {
@@ -28,15 +28,15 @@ func (i *Interface) ring(idx uint32) uintptr {
 
 }
 
-func (i *Interface) GetRing(RingIndex interface{}, direction Direction) *NetmapRing {
-	var ring_ptr uintptr
-	idx := ifaceTOuint32(RingIndex)
+func (i *Interface) GetRing(ringIndex interface{}, direction Direction) *NetmapRing {
+	var ringPtr uintptr
+	idx := ifaceTOuint32(ringIndex)
 	if direction == TX {
-		ring_ptr = i.ring(idx)
+		ringPtr = i.ring(idx)
 	} else {
-		ring_ptr = i.ring(idx + i.Nif.TxRings + 1)
+		ringPtr = i.ring(idx + i.Nif.TxRings + 1)
 	}
-	return (*NetmapRing)(unsafe.Pointer(ring_ptr))
+	return (*NetmapRing)(unsafe.Pointer(ringPtr))
 }
 
 func (i *Interface) RxSync() error {

--- a/ring.go
+++ b/ring.go
@@ -19,7 +19,7 @@ type NetmapRing struct {
 	Ts        syscall.Timeval
 	pad1      [72]byte
 	Sem       [128]uint8
-	Slots     Slot //NmSlot is here
+	Slots     Slot // NmSlot is here
 }
 
 func (r *NetmapRing) GetSlots() *[]Slot {
@@ -39,7 +39,7 @@ func (r *NetmapRing) Base() (uintptr, uintptr) {
 }
 
 func (r *NetmapRing) Next(i uint32) uint32 {
-	i = i + 1
+	i++
 
 	if i == r.NumSlots {
 		i = 0
@@ -62,12 +62,12 @@ func (r *NetmapRing) RingIsEmpty() bool {
 
 }
 
-func (r *NetmapRing) SlotBuffer(slot_ptr *Slot) unsafe.Pointer {
-	idx := uintptr((*slot_ptr).Idx)
+func (r *NetmapRing) SlotBuffer(slotPtr *Slot) unsafe.Pointer {
+	idx := uintptr(slotPtr.Idx)
 	BasePtr, BufSize := r.Base()
 	return unsafe.Pointer(BasePtr + idx*BufSize)
 }
 
 func (r *NetmapRing) BufferSlice(slotPtr *Slot) *[]byte {
-	return (*[]byte)(PtrSliceFrom(r.SlotBuffer(slotPtr), int((*slotPtr).Len)))
+	return (*[]byte)(PtrSliceFrom(r.SlotBuffer(slotPtr), int(slotPtr.Len)))
 }


### PR DESCRIPTION
Reduce the amount of warnings from linters.

- Put a space between a "//" and a comment text
- Don't use snake_case names
- Use i++ instead of i=i+1
- Remove redundant explicit derefs

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>